### PR TITLE
Start combat + Combat Manager as Autoload (singleton)

### DIFF
--- a/combat_gui.tscn
+++ b/combat_gui.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=13 format=3 uid="uid://c8aqefohsnwby"]
+[gd_scene load_steps=12 format=3 uid="uid://c8aqefohsnwby"]
 
 [ext_resource type="Script" path="res://combat_gui.gd" id="1_dgkmr"]
 [ext_resource type="Texture2D" uid="uid://cbusnos6bqvqa" path="res://art/environment/BG 2.0/BG/battleback1.png" id="2_l3qbx"]

--- a/combat_manager.gd
+++ b/combat_manager.gd
@@ -2,7 +2,9 @@ extends Node
 
 @export var combatHUDScene : PackedScene
 
-func start_combat_scene(party : Array[CharacterBody2D], enemies : Array[Area2D]):
+func start_combat_scene(party : Array[CharacterBody2D], enemies : Array[Area2D], path):
+	combatHUDScene = load(path)
+	
 	if not combatHUDScene:
 		print("No combat scene selected! Please select one in the editor.")
 		return

--- a/enemy.gd
+++ b/enemy.gd
@@ -3,8 +3,7 @@ extends Area2D
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	pass # Replace with function body.
-
+	add_to_group("enemy")
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta):

--- a/project.godot
+++ b/project.godot
@@ -15,6 +15,10 @@ run/main_scene="res://first_scene.tscn"
 config/features=PackedStringArray("4.3", "Forward Plus")
 config/icon="res://icon.svg"
 
+[autoload]
+
+CombatManager="*res://combat_manager.gd"
+
 [filesystem]
 
 import/blender/enabled=false

--- a/second_scene.gd
+++ b/second_scene.gd
@@ -18,5 +18,5 @@ func _process(delta):
 
 
 func _on_enemy_body_entered(body: PhysicsBody2D):
-	#combat_system.start_combat_scene()
-	pass
+	var enemy = get_tree().get_nodes_in_group("enemy")
+	CombatManager.start_combat_scene([player, player], [enemy], "res://combat_gui.tscn")

--- a/second_scene.tscn
+++ b/second_scene.tscn
@@ -13,7 +13,7 @@ layer_2/tile_data = PackedInt32Array(-327685, 458752, 2, -262149, 458752, 2, -19
 
 [node name="Player" parent="." instance=ExtResource("2_jttwt")]
 
-[node name="Enemy" parent="." instance=ExtResource("3_msafq")]
+[node name="Enemy" parent="." groups=["enemy"] instance=ExtResource("3_msafq")]
 position = Vector2(1048, 307)
 
 [connection signal="body_entered" from="Enemy" to="." method="_on_enemy_body_entered"]


### PR DESCRIPTION
We want the current Combat Manager to be a singleton class using Godot's autoload https://docs.godotengine.org/en/stable/tutorials/scripting/singletons_autoload.html

- implement combat manager as an autoload scene
- added the enemy group/tag on all enemies
- on any scene ready, scans/picks up all enemies in a scene with the group/tag
- Transition overworld → combat (loading states)

Next steps + Questions?
- what are the loading states and how to retrieve those?